### PR TITLE
Fixes typo in first exercise instructions

### DIFF
--- a/src/exercise/01.html
+++ b/src/exercise/01.html
@@ -9,7 +9,7 @@
 <!--   💰 document.createElement('div')) -->
 
 <!-- 🐨 Set the div's textContent to 'Hello World' and className to 'container' -->
-<!--   💰 div.textConent = '...' -->
+<!--   💰 div.textContent = '...' -->
 
 <!-- 🐨 Append the div to the root div using `append` -->
 <!--   💰 document.getElementById('root') -->


### PR DESCRIPTION
In the instructions for inserting the text it specifies the use of
`div.textConent` when it should be `div.textContent`