### PR TITLE
fix #78: use https for the npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-registry=http://registry.npmjs.org/
+registry=https://registry.npmjs.org/
 package-lock=true


### PR DESCRIPTION
Summary of #78: @coreysmithdesign was having trouble in this repo getting packages from npm, and it turns out his network was pretty much blocking non-secure network requests. They fixed it themselves and closed the issue, but I figured a commit to amend the npm registry specified in `.npmrc` to use `https` instead of `http` is a good idea.

Can't imagine we're intentionally requesting `http://registry.npmjs.org/` instead of `https://registry.npmjs.org/`, but hopefully someone who knows more than I on this will confirm or reject 😄 

Seems like the same thing happens in other workshop repos as well... https://github.com/kentcdodds/react-hooks/blob/main/.npmrc