### PR TITLE
usernameInput changed to username

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -25,7 +25,7 @@ get an "alert" showing what you typed.
 
 - Via their index: `event.target.elements[0].value`
 - Via the elements object by their `name` or `id` attribute:
-  `event.target.elements.usernameInput.value`
+  `event.target.elements.username.value`
 - There's another that I'll save for the extra credit
 
 ## Extra Credit


### PR DESCRIPTION
In the example `usernameInput` has been changed to `username`
It would probably help others to have it explicit as the `usernameInput` does not match the name in the 06.js file ...unless it was intentional. In that case, don't worry about this pull request