### PR TITLE
Added repository URL to fix codegen issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "title": "React Fundamentals ⚛",
   "keywords": [],
   "homepage": "http://react-fundamentals.netlify.app/",
+  "repository": {
+    "url": "https://github.com/kentcdodds/react-fundamentals"
+  },
   "license": "GPL-3.0-only",
   "main": "src/index.js",
   "engines": {


### PR DESCRIPTION
## Description

Fixes the error

```bash
Failed to compile.

./src/index.js
Error: /Users/nickytonline/dev/react-fundamentals/src/index.js: codegen.macro: Cannot find a repository URL for this workshop. Check that the package.json at "/Users/nickytonline/dev/react-fundamentals/package.json" has {"repository": {"url": "this should be set to a github URL"}} Learn more: https://www.npmjs.com/package/codegen.macro
    at Array.forEach (<anonymous>)
```

## Related Documents/Issues

Closes #121 

![Man slapping duct tape on a cylinder of water that is leaking](https://media.giphy.com/media/VeSvZhPrqgZxx2KpOA/giphy.gif)