### PR TITLE
Improve explanation

### DIFF
--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -37,7 +37,10 @@ returns the React element. Then you can interpolate a call to that function in
 your JSX.
 
 ```jsx
-<div>{message('Hello World')}</div>
+<div className="container">
+  {message('Hello World')}
+  {message('Goodbye World')}
+</div>
 ```
 
 This is not how we write custom React components, but this is important for you


### PR DESCRIPTION
Previously it was just: `<div>{message('Hello World')}</div>`

Which makes an impression that you could with that function, change the `className` of the surrounding div which is impossible. This makes it a bit more clear how the functions would work and that they have to return the entire `div`.