### PR TITLE
Add .eslintcache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 build
 .idea/
 .vscode/
+.eslintcache


### PR DESCRIPTION
If you clone react-fundamentals and run `node setup` you will, under some circumstances, have an uncommitted `.eslintcache`.