### PR TITLE
Update Exercise 04 instructions

### DIFF
--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -36,12 +36,12 @@ the React elements for this:
 <div className="message">{children}</div>
 ```
 
-So we need to make a function which accepts the `children` as an argument and
-returns the React element. Then you can interpolate a call to that function in
-your JSX.
+So we need to make a function which accepts an object argument with a `children`
+property and returns the React element. Then you can interpolate a call to that
+function in your JSX.
 
 ```jsx
-<div>{message('Hello World')}</div>
+<div>{message({ children: 'Hello World' })}</div>
 ```
 
 This is not how we write custom React components, but this is important for you


### PR DESCRIPTION
The instructions define a `message` signature different than the one provided by 💰 Marty the Money Bag in the exercise file itself. In addition, following the instructions signature will force a refactor when updating to use `React.createElement` in Extra Credit 1.

If this is intentional (perhaps to keep the instructions as simple as possible), then please close this PR. Opening in case I'm not the only one a bit mislead by the unnecessary difference.