### PR TITLE
Node 17 isn't supported so remove from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ## System Requirements
 
 - [git][git] v2.13 or greater
-- [NodeJS][node] `12 || 14 || 15 || 16 || 17`
+- [NodeJS][node] `12 || 14 || 15 || 16`
 - [npm][npm] v6 or greater
 
 All of these must be available in your `PATH`. To verify things are set up


### PR DESCRIPTION
Node 17 is not supported (e7eca6e13d68685c9a967733155af539c6dc9315) but was still listed in the README.

Edit: I've discovered this is an issue with the other repos for this course also, but haven't made PR's to the other repos - would be good to fix everywhere though.