### PR TITLE
Adjust regex in test

### DIFF
--- a/src/__tests__/06.extra-2.js
+++ b/src/__tests__/06.extra-2.js
@@ -22,7 +22,7 @@ test('calls the onSubmitUsername handler when the submit is fired', () => {
   userEvent.type(input, value)
   expect(submit).toBeDisabled() // upper-case
 
-  const output = screen.getByText(/lower case/i)
+  const output = screen.getByText(/lower\s?case/i)
   expect(output).toBeInTheDocument()
   alfredTip(
     output.getAttribute('role') !== 'alert',


### PR DESCRIPTION
Upper and lower case are both accounted for, but `lower case` and `lowercase` are both acceptable spellings. Adding an optional whitespace for learners who choose to spell it without a space.