### PR TITLE
Update example link

### DIFF
--- a/src/exercise/01.html
+++ b/src/exercise/01.html
@@ -5,7 +5,7 @@
 <!-- 🐨 Then create a <script type="module"> for your JavaScript -->
 <!--   📜 https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attributes -->
 <!--   📜 https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules -->
-<!--   📜 https://github.com/mdn/js-examples/tree/master/modules -->
+<!--   📜 https://github.com/mdn/js-examples/tree/master/module-examples -->
 
 <!-- These next instructions are to be written in JavaScript in the <script> tag -->
 <!-- 🐨 Create a div -->


### PR DESCRIPTION
It looks like one of the links in 01.html no longer exists. I assume the page being linked to is the module examples directory.