### PR TITLE
docs(exercise-3): add links to JSX helper docs

### DIFF
--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -76,8 +76,8 @@ https://reactjs.org/docs/introducing-jsx.html
 
 Here are a few sections of particular interest for this extra credit:
 
-- https://reactjs.org/docs/introducing-jsx.html#embedding-expressions-in-jsx
-- https://reactjs.org/docs/introducing-jsx.html#specifying-attributes-with-jsx
+- [https://reactjs.org/docs/introducing-jsx.html#embedding-expressions-in-jsx](https://reactjs.org/docs/introducing-jsx.html#embedding-expressions-in-jsx)
+- [https://reactjs.org/docs/introducing-jsx.html#specifying-attributes-with-jsx](https://reactjs.org/docs/introducing-jsx.html#specifying-attributes-with-jsx)
 
 ### 2. 💯 spread props
 


### PR DESCRIPTION
Hi, I thought making the list of items accessible to navigate seamlessly would help us retain focus while going through the workshop. 