### PR TITLE
Fix: Add missing label and input attributes on 06

### DIFF
--- a/src/exercise/06.js
+++ b/src/exercise/06.js
@@ -22,8 +22,8 @@ function UsernameForm({onSubmitUsername}) {
   return (
     <form>
       <div>
-        <label>Username:</label>
-        <input type="text" />
+        <label htmlFor="usernameInput">Username:</label>
+        <input id="usernameInput" type="text" />
       </div>
       <button type="submit">Submit</button>
     </form>


### PR DESCRIPTION
### What?
For Exercise 06, we were given two choices on how to target the input in our form:

- use the index: `event.target.elements[0].value`
- use the ID: `event.target.elements.usernameInput.value`

The input does not have an ID set, which I at first thought was intended. If we chose to take the ID approach, we'd need to add that ID ourselves. Makes sense.

However, the tests are failing because _the `label`_ is also missing a `for` or `aria-labelledby` attribute.
Running the tests out-of-the-box for the exercise gives me the following error:

```
TestingLibraryElementError: Found a label with the text of: /username/i, however no form control was found associated to that label. Make sure you're using the "for" attribute or "aria-labelledby" attribute correctly.
```

### How?

I've just added `htmlFor="usernameInput"` to the `label` and `id="usernameInput"` for the `input`. Now when you run the tests before making any changes to the file for the exercise, the test errors will be complaining about `alert` not being called. To me, this should be the expected behavior.

If this behavior was actually intended to be an exercise for users, I can close this PR! 😅 

