### PR TITLE
Update 04.md

### DIFF
--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -152,8 +152,8 @@ I'll get an error in the console.
 For this extra credit, add `propTypes` support to your updated component
 (remember to update it to have the subject and greeting).
 
-🦉 Note that prop types add some runtime overhead resulting in sub-optimal
-performance, so they are not run in production.
+🦉 Note that prop types validation add some runtime overhead resulting in sub-optimal
+performance, so the validation functions are not run in production.
 
 📜 Read more about prop-types:
 


### PR DESCRIPTION
Edited the prop types section to make it clear that the validation functions are actually slower and are then stripped on production builds, not the prop types definition themselves.