### PR TITLE
Fix: Removing className as props from Box component - 05-Extra 2

### DIFF
--- a/src/final/05.extra-2.js
+++ b/src/final/05.extra-2.js
@@ -5,7 +5,7 @@
 import * as React from 'react'
 import '../box-styles.css'
 
-function Box({style, size, className = '', ...otherProps}) {
+function Box({style, size, ...otherProps}) {
   const sizeClassName = size ? `box--${size}` : ''
   return (
     <div


### PR DESCRIPTION
**2. 💯 accept a size prop to encapsulate styling.  ------- 5th Assignment extra credit 2**

For this challenge we are sending **size** as props to **Box component** so **className** is no longer necessary and it's not being used.