### PR TITLE
Update incorrect variable name in exercise 02 README

### DIFF
--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -57,9 +57,9 @@ Here's a simple example of the API:
 ```javascript
 const elementProps = {id: 'element-id', children: 'Hello world!'}
 const elementType = 'h1'
-const reactElement = React.createElement(elementType, elementProps)
+const rootElement = React.createElement(elementType, elementProps)
 const root = ReactDOM.createRoot(rootElement)
-root.render(reactElement)
+root.render(rootElement)
 ```
 
 > 🦉 NOTE: prior to React v18, the API was: `ReactDOM.render` and that's what


### PR DESCRIPTION
The JavaScript snippet in the README for exercise 02 contains refers to a variable name that does not exist. 