### PR TITLE
Remove an extra list element from `Rendering Arrays` tutorial

### DIFF
--- a/src/exercise/07.md
+++ b/src/exercise/07.md
@@ -137,9 +137,6 @@ const element = (
     {list.map(listItem => (
       <li key={listItem.id}>{listItem.value}</li>
     ))}
-    {list.map(listItem => (
-      <li key={listItem.id}>{listItem.value}</li>
-    ))}
   </ul>
 )
 ```


### PR DESCRIPTION
- This change removes the duplicate list element present in the `Rendering Arrays` tutorial.
-  duplicate list in docs preview

![image](https://user-images.githubusercontent.com/118078892/216824928-b2eecc8e-8689-4aa8-a612-173ad6a1cdab.png)
