### PR TITLE
Add support to nodejs 19.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "GPL-3.0-only",
   "main": "src/index.js",
   "engines": {
-    "node": "14 || 16 || 18",
+    "node": "14 || 16 || 18 || 19",
     "npm": ">=8.16.0"
   },
   "dependencies": {


### PR DESCRIPTION
I am using https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V19.md#19.6.0 on my machine and everything seems to work fine.  I think we are good adding this new version here