### PR TITLE
Update 06.md with up-to-date link to React documentation

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -46,7 +46,7 @@ will set the `current` property to the DOM node that's rendered.
 
 So if you create an `inputRef` object via `React.useRef`, you could access the
 value via: `inputRef.current.value`
-(📜[https://reactjs.org/docs/hooks-reference.html#useref](https://reactjs.org/docs/hooks-reference.html#useref))
+(📜[https://reactjs.org/docs/hooks-reference.html#useref](https://react.dev/reference/react/useRef))
 
 Try to get the usernameInput's value using a ref.
 


### PR DESCRIPTION
The previous link still linked to the outdated React docs, had to click another link on there to get to the up-to-date documentation.