### PR TITLE
Exercise 2: Add a missing(?) line to example code

### DIFF
--- a/src/exercise/02.md
+++ b/src/exercise/02.md
@@ -55,6 +55,7 @@ Once you include the script tags, you'll have two new global variables to use:
 Here's a simple example of the API:
 
 ```javascript
+const rootElement = document.getElementById('root')
 const elementProps = {id: 'element-id', children: 'Hello world!'}
 const elementType = 'h1'
 const reactElement = React.createElement(elementType, elementProps)


### PR DESCRIPTION
Newbie React devs might be thrown by the missing rootElement in this case, not yet having been reassured that it should be created the same as in vanilla JavaScript. 😄 It looks juuuust enough like a typo to trip you up, imho.

(Note: I can see the case for leaving this in, as it *does* discourage viewers from just copy-pasting example code... 😃 But I think this video series does an excellent job of discouraging that already.)